### PR TITLE
Added a note to mobileWarning about arrow keys

### DIFF
--- a/mobileWarning.html
+++ b/mobileWarning.html
@@ -14,7 +14,7 @@
 <body>
 	<div>
 	<strong>
-	A Dark Room isn't really mobile-friendly<br/>
+	A Dark Room isn't really mobile-friendly, and it requires arrow keys.<br/>
 	Sorry about that!<br/>
 	</strong><br/>
 	Of course you can <a href='index.html?ignorebrowser=true'>play anyway</a>, but it probably won't work!


### PR DESCRIPTION
An HN commenter noted that he ignored the mobilewarning and tried the game and found it worked. That is, until he got to the Embark stage and found himself arrow key-less. This warning is slightly more verbose to avoid similar situations.
