### PR TITLE
(SPOILERS) Fixed a bug in which the share/restart buttons disappeared...

### DIFF
--- a/script/space.js
+++ b/script/space.js
@@ -247,7 +247,7 @@ var Space = {
 			}
 		}, 1000);
 		
-		setTimeout(function() {
+		Space._panelTimeout = setTimeout(function() {
 			$('#spacePanel, .deleteSave, .share').animate({color: 'white'}, 500, 'linear');
 		}, Space.FTB_SPEED / 2);
 		
@@ -308,6 +308,7 @@ var Space = {
 		Space.done = true;
 		clearInterval(Space._timer);
 		clearInterval(Space._shipTimer);
+		clearTimeout(Space._panelTimeout);
 		
 		// Craaaaash!
 		$('body').removeClass('noMask').stop().animate({


### PR DESCRIPTION
During the space sequence, there's a point where everything fades from black to white as the ship gets further away. The timer for this, however, doesn't get turned off if the ship crashes before it's set to go off, causing the buttons to (visibly, at least) fade away. I'm not sure why anyone would want to make use of the restart button this far into the game, anyway, but a bug is a bug.
