### PR TITLE
events.js: Item dropping improvements

### DIFF
--- a/script/events.js
+++ b/script/events.js
@@ -526,7 +526,6 @@ var Events = {
 		Path.outfit[thing] -= num;
 		Events.getLoot(btn.closest('.button'));
 		World.updateSupplies();
-		$('#dropMenu').remove();
 	},
 	
 	getLoot: function(btn) {
@@ -548,6 +547,7 @@ var Events = {
 						}
 					});
 				} else {
+					// #dropMenu gets removed by this.
 					btn.text(name + ' [' + num + ']');
 				}
 				var curNum = Path.outfit[name];
@@ -555,7 +555,14 @@ var Events = {
 				curNum++;
 				Path.outfit[name] = curNum;
 				World.updateSupplies();
-			} else {
+
+				// Update weight and free space variables so we can decide
+				// whether or not to bring up/update the drop menu.
+				weight = Path.getWeight(name);
+				freeSpace = Path.getFreeSpace();
+			}
+
+			if(weight > freeSpace && btn.data('numLeft') > 0) {
 				// Draw the drop menu
 				Engine.log('drop menu');
 				$('#dropMenu').remove();


### PR DESCRIPTION
Item drop menu no longer disappears after clicking to drop something, making the process of discarding multiples of some item in favor of another much more painless. 

The behavior that this branch brings is pretty straight-forward. The drop menu stays in place after dropping something (updating to reflect any changes: if you click yourself out of fur, fur gets removed from the list). From my experience testing this so far, it feels extremely natural and intuitive, and much easier to deal with in comparison with the click-fest of before.
