### PR TITLE
Updates README to not use rawgithub

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,4 +3,4 @@ A Dark Room
 
 A Minimalist Text Adventure Game
 
-[Click to play](http://rawgithub.com/Continuities/adarkroom/master/index.html)
+[Click to play](http://adarkroom.doublespeakgames.com/)


### PR DESCRIPTION
Super simple change to fix blacklisted url _http://rawgithub.com/Continuities/adarkroom/master/index.html_ to _http://adarkroom.doublespeakgames.com/_ in README

This is discussed in #4
