### PR TITLE
Add disableSelection to stop highlighting

### DIFF
--- a/script/engine.js
+++ b/script/engine.js
@@ -250,6 +250,7 @@ var Engine = {
     string64 = string64.replace(/\s/g, '');
     string64 = string64.replace(/\./g, '');
     string64 = string64.replace(/\n/g, '');
+    Engine.enableSelection();
     Events.startEvent({
     	title: 'Export',
     	scenes: {
@@ -259,7 +260,8 @@ var Engine = {
     			buttons: {
     				'done': {
     					text: 'got it',
-    					nextScene: 'end'
+    					nextScene: 'end',
+    					onChoose: Engine.disableSelection
     				}
     			}
     		}
@@ -571,6 +573,11 @@ var Engine = {
 	disableSelection: function() {
 		document.onselectstart = function() {return false;} // this is for IE
 		document.onmousedown = function() {return false;} // this is for the rest
+	},
+
+	enableSelection: function() {
+		document.onselectstart = function() {return true;}
+		document.onmousedown = function() {return true;}
 	},
 	
 	handleStateUpdates: function(e){


### PR DESCRIPTION
This is a fix to #76.

It disables selection with JS rather than CSS because of browsers not supporting CSS consistently.

I'm currently playing through with this build and it seems alright at start.
