### PR TITLE
Make keydown return true unless arrow key

### DIFF
--- a/script/engine.js
+++ b/script/engine.js
@@ -549,7 +549,7 @@
 					Engine.activeModule.keyDown(e);
 				}
 			}
-			return false;
+			return !(jQuery.inArray(window.event.keycode, [37,38,39,40]));
 		},
 		
 		keyUp: function(e) {


### PR DESCRIPTION
This prevents the window from jumping around on The Dusty Road for low resolution users, but allows other keydowns to work (Like CTRL-T)

Resolves #92
