### PR TITLE
add missing comma to langs definition

### DIFF
--- a/lang/langs.js
+++ b/lang/langs.js
@@ -1,6 +1,6 @@
 var langs = {
- 'en':'english',
- 'fr':'français',
- 'cn':'简体中文',
- 'jp':'日本語'
+	'en':'english',
+	'fr':'français',
+	'cn':'简体中文',
+	'jp':'日本語'
 }


### PR DESCRIPTION
Noticed this syntax error in the console. Comma was missed when Chinese language support was added recently.
