### PR TITLE
Add fire and temperature to State.game

### DIFF
--- a/script/room.js
+++ b/script/room.js
@@ -549,7 +549,7 @@ var Room = {
 	onArrival: function(transition_diff) {
 		Room.setTitle();
 		if(Room.changed) {
-			Notifications.notify(Room, _("the fire is {0}", $SM.get('game.temperature.text')));
+			Notifications.notify(Room, _("the fire is {0}", $SM.get('game.fire.text')));
 			Notifications.notify(Room, _("the room is {0}", $SM.get('game.temperature.text')));
 			Room.changed = false;
 		}


### PR DESCRIPTION
Adding fire and temperature to game state will allow persistence of the
fire and temp on reloads.

Based off and closes #103 
