### PR TITLE
Change delay of winFight function

### DIFF
--- a/script/events.js
+++ b/script/events.js
@@ -481,7 +481,7 @@ var Events = {
 				} catch(e) {
 					// It is possible to die and win if the timing is perfect. Just let it fail.
 				}
-			}, 3000);
+			}, 1000);
 		});
 	},
 	


### PR DESCRIPTION
I have hit leave too many times when it was supposed to be stab. This fixed it for me. This is in response to issue #8 Don't move buttons in dialogs to avoid unintended clicks.  I has the bonus of giving 2 more seconds to hit that eat meat button.
