### PR TITLE
Fixed bug where player could take unavailable items onto dusty path

### DIFF
--- a/script/path.js
+++ b/script/path.js
@@ -178,6 +178,7 @@ var Path = {
 			var have = $SM.get('stores["'+k+'"]');
 			var num = Path.outfit[k];
 			num = typeof num == 'number' ? num : 0;
+			if (have < num) { num = have; }
 			var numAvailable = $SM.get('stores["'+k+'"]', true);
 			var row = $('div#outfit_row_' + k.replace(' ', '-'), outfit);
 			if((store.type == 'tool' || store.type == 'weapon') && have > 0) {


### PR DESCRIPTION
Hi Doublespeak games,

I discovered _A Dark Room_ through GitHub a few days ago, got hooked and really enjoyed the experience. Thanks for an awesome game—it's clear that a lot of love has gone into it. While playing, I noticed a bug in the Dusty Path inventory. 

---

Some repro steps:
1. Get your total inventory of a particular resource (e.g., cured meat) down to a low amount.
2. Embark on a Dusty Path expedition, taking with you most of your supply of that resource.
3. Return from the expedition and adjust your village workers in a way such that your total supply dips below the amount you just brought back.
4. **The bug:** Head back to the Dusty Path screen and hover over that resource. Note that you're still on track to bring the same number of items with you, and that your "available" number is negative.
5. **Yikes!** Embark on a Dusty Path expedition and immediately return—your inventory has adjusted back to the positive number. Free stuff!

This small PR adjusts the `num` variable to match the total inventory (`have`) whenever `num < have`. The `#updateOutfitting` method needs to run, but this happens whenever a player switches to the Dusty Path view or updates any inventory quantities on the Dusty Path menu.

---

As a total aside: This is my first-ever unsolicited PR! Feel free to let me know if I'm violating etiquette. :)
