### PR TITLE
Lighten up disabled button color to be more obvious.

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -195,8 +195,8 @@ div.button:hover {
 
 div.button.disabled, div.button.disabled:hover {
 	cursor: default;
-	border-color: grey;
-	color: grey;
+	border-color: #b2b2b2;
+	color: #b2b2b2;
 	text-decoration: none;
 }
 


### PR DESCRIPTION
I usually play with the lights off but when I was unable to build certain objects like the cart or lodge I decided to switch to lights on for fun. I saw there wasn't much contrast between the disabled buttons on the lights on screen compared to the lights off. Just a small change that, I think, vastly improves usability.
