### PR TITLE
Fix some strings in the Spanish localization

### DIFF
--- a/lang/es/strings.po
+++ b/lang/es/strings.po
@@ -388,7 +388,7 @@ msgstr "el extraño tiembla, y murmura despacio. sus palabras no se entienden."
 
 #: ../../script/room.js:736
 msgid "the stranger in the corner stops shivering. her breathing calms."
-msgstr "el extraño en la esquina deja de templar. su respiración se calma."
+msgstr "el extraño en la esquina deja de temblar. su respiración se calma."
 
 #: ../../script/room.js:890 ../../script/room.js:938
 msgid "not enough "


### PR DESCRIPTION
While in English "compass" can be used both for a navigation aid and a drawing tool, "compás" in Spanish is used only for the later. "Brújula" is the correct translation for the former.

"Sulfuro" is a word more commonly used in chemistry for compounds. Through it's correct, in real-life people tend to use more "azufre", which is the name for the atomic element.

"Trampa" isn't a correct translation for "trapper". "Trampa" means "trap". A people which place and use traps is "trampero".

"Constructora" is a word normally employed to talk about companies which build buildings. We don't have a generic word like "builder" for somebody that can build a wide range of things. Therefore I've replaced it with "manitas" ("handyman"), which is somewhat colloquial but that anybody will understand what you're referring to.
