### PR TITLE
Change temp and fire to take from value not text for i18n

### DIFF
--- a/script/room.js
+++ b/script/room.js
@@ -540,8 +540,8 @@ var Room = {
 		}
 		setTimeout($SM.collectIncome, 1000);
 
-		Notifications.notify(Room, _("the room is {0}", $SM.get('game.temperature.text')));
-		Notifications.notify(Room, _("the fire is {0}", $SM.get('game.fire.text')));
+		Notifications.notify(Room, _("the room is {0}", Room.TempEnum.fromInt($SM.get('game.temperature.value')).text));
+		Notifications.notify(Room, _("the fire is {0}", Room.FireEnum.fromInt($SM.get('game.fire.value')).text));
 	},
 	
 	options: {}, // Nothing for now
@@ -549,8 +549,8 @@ var Room = {
 	onArrival: function(transition_diff) {
 		Room.setTitle();
 		if(Room.changed) {
-			Notifications.notify(Room, _("the fire is {0}", $SM.get('game.fire.text')));
-			Notifications.notify(Room, _("the room is {0}", $SM.get('game.temperature.text')));
+			Notifications.notify(Room, _("the fire is {0}", Room.FireEnum.fromInt($SM.get('game.fire.value')).text));
+			Notifications.notify(Room, _("the room is {0}", Room.TempEnum.fromInt($SM.get('game.temperature.value')).text));
 			Room.changed = false;
 		}
 		if($SM.get('game.builder.level') == 3) {
@@ -667,7 +667,7 @@ var Room = {
 		if(Engine.activeModule != Room) {
 			Room.changed = true;
 		}
-		Notifications.notify(Room, _("the fire is {0}", $SM.get('game.fire.text')), true);
+		Notifications.notify(Room, _("the fire is {0}", Room.FireEnum.fromInt($SM.get('game.fire.value')).text), true);
 		if($SM.get('game.fire.value') > 1 && $SM.get('game.builder.level') < 0) {
 			$SM.set('game.builder.level', 0);
 			Notifications.notify(Room, _("the light from the fire spills from the windows, out into the dark"));
@@ -698,11 +698,11 @@ var Room = {
 		var old = $SM.get('game.temperature.value');
 		if($SM.get('game.temperature.value') > 0 && $SM.get('game.temperature.value') > $SM.get('game.fire.value')) {
 			$SM.set('game.temperature',Room.TempEnum.fromInt($SM.get('game.temperature.value') - 1));
-			Notifications.notify(Room, _("the room is {0}" , $SM.get('game.temperature.text')), true);
+			Notifications.notify(Room, _("the room is {0}" , Room.TempEnum.fromInt($SM.get('game.temperature.value')).text), true);
 		}
 		if($SM.get('game.temperature.value') < 4 && $SM.get('game.temperature.value') < $SM.get('game.fire.value')) {
 			$SM.set('game.temperature', Room.TempEnum.fromInt($SM.get('game.temperature.value') + 1));
-			Notifications.notify(Room, _("the room is {0}" , $SM.get('game.temperature.text')), true);
+			Notifications.notify(Room, _("the room is {0}" , Room.TempEnum.fromInt($SM.get('game.temperature.value')).text), true);
 		}
 		if($SM.get('game.temperature.value') != old) {
 			Room.changed = true;


### PR DESCRIPTION
This change fixes the issue of the game using the text from the saved
fire and temperature states. Clean up of the `game` store should be done
before next release to just save fire and temperature values only in
`game.fire` and `game.temperature` respectively.

I disagree with how #156 tries to handle the issue as it would require fixing .po/.pot files.
As a collaborator myself, I have biased judgement towards these PRs so @Continuities
will have to do the deciding.

Closes #135
