### PR TITLE
Prestige shouldn't contain decimals

### DIFF
--- a/script/prestige.js
+++ b/script/prestige.js
@@ -66,7 +66,7 @@ var Prestige = {
   
 	collectStores : function() {
 		var prevStores = $SM.get('previous.stores');
-		if(prevStores !== null) {
+		if(prevStores != null) {
 			var toAdd = {};
 			for(var i in this.storesMap) {
 				var s = this.storesMap[i];


### PR DESCRIPTION
Corrects issue of Prestige scoring containing decimals and Infinite as well as JSHint suggestion.

Closes #69 

Awesome debugging work by @alzeih
