### PR TITLE
Include state of Path outfit in save game

### DIFF
--- a/script/path.js
+++ b/script/path.js
@@ -46,7 +46,7 @@ var Path = {
 			cooldown: World.DEATH_COOLDOWN
 		}).appendTo(this.panel);
 		
-		Path.outfit = {};
+		Path.outfit = $SM.get('outfit');
 		
 		Engine.updateSlider();
 		
@@ -269,6 +269,7 @@ var Path = {
 			var maxExtraByStore  = $SM.get('stores["'+supply+'"]', true) - cur;
 			var maxExtraByBtn    = btn.data;
 			Path.outfit[supply] = cur + Math.min(maxExtraByBtn, Math.min(maxExtraByWeight, maxExtraByStore));
+			$SM.set('outfit['+supply+']', Path.outfit[supply])
 			Path.updateOutfitting();
 		}
 	},
@@ -280,6 +281,7 @@ var Path = {
 		cur = typeof cur == 'number' ? cur : 0;
 		if(cur > 0) {
 			Path.outfit[supply] = Math.max(0, cur - btn.data);
+			$SM.set('outfit['+supply+']', Path.outfit[supply])
 			Path.updateOutfitting();
 		}
 	},
@@ -288,6 +290,7 @@ var Path = {
 		Path.setTitle();
 		Path.updateOutfitting();
 		Path.updatePerks(true);
+		$SM.set('outfit', Path.outfit);
 
 		Engine.moveStoresView($('#perks'), transition_diff);
 	},
@@ -300,6 +303,7 @@ var Path = {
 		for(var k in Path.outfit) {
 			$SM.add('stores["'+k+'"]', -Path.outfit[k]);
 		}
+		$SM.remove('outfit');
 		World.onArrival();
 		$('#outerSlider').animate({left: '-700px'}, 300);
 		Engine.activeModule = World;

--- a/script/state_manager.js
+++ b/script/state_manager.js
@@ -35,7 +35,8 @@ var StateManager = {
 			'timers',
 			'game', 		//mostly location related: fire temp, workers, population, world map, etc
 			'playStats',	//anything play related: play time, loads, etc
-			'previous' 		// prestige, score, trophies (in future), achievements (again, not yet), etc
+			'previous',		// prestige, score, trophies (in future), achievements (again, not yet), etc
+			'outfit'			// used to temporarily store the items to be taken on the path
 		];
 		
 		for(var which in cats) {


### PR DESCRIPTION
Related to #162. This fixes the issue of the current path outfit (i.e. equipment selected before embarking) being lost on save game/load.

Using the StateManager:
- Save changes to state of the path outfit in `outfit[resource]` whenever a resource is incremented/decremented.
- Clear out `outfit` on embarking (just after the resources are decremented from the stores).
- Update stored `outfit` on arrival to match the `Path.outfit` (i.e. whatever is remaining after their journey outside).
- Load the saved `outfit` when initialising the path screen (StateManager will initialise it to empty, thankfully).

Issues:
The object stored in `outfit` is really just an exact copy of `Path.outfit` (until it is modified when out on the path). If they got out of sync before then it would be bad.

It's my first change to ADR, so I expect I'm missing something!

Perhaps the State shouldn't be used for 'temporary' storage like this? It does seem like the simplest way to get the contents of the path outfit to persist/load with the save game, though.
