### PR TITLE
Make quantity-adjust buttons bigger

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -266,7 +266,7 @@ div.button div.cooldown {
 }
 
 .upManyBtn, .dnManyBtn {
-	right: -11px;
+	right: -15px;
 }
 
 .upBtn.disabled, .dnBtn.disabled, .upManyBtn.disabled, .dnManyBtn.disabled {
@@ -274,11 +274,11 @@ div.button div.cooldown {
 }
 
 .upBtn {
-	top: -2px;
+	top: -3px;
 }
 
 .upManyBtn {
-	top: -2px;
+	top: -3px;
 }
 
 .upBtn:after, .upBtn:before, .upManyBtn:after, .upManyBtn:before {
@@ -320,22 +320,28 @@ div.button div.cooldown {
 	top: 4px;
 }
 
+/* Overall size of buttons controlled by this style 
+   border-width and margin-left should be the same. */
+.upBtn:before, .dnBtn:before, .upManyBtn:before, .dnManyBtn:before {
+	border-width: 6px;
+	left: 50%;
+	margin-left: -6px;
+}
+
+/* Thickness of up/down button lines controlled by this style.
+   border-width and margin-left should be the same.
+   Thickness = :before.border-width minus :after.border-width */
 .upBtn:after, .dnBtn:after {
+	border-width: 4px;
+	left: 50%;
+	margin-left: -4px;
+}
+
+/* See comment on .upBtn:after, .dnBtn:after */
+.upManyBtn:after, .dnManyBtn:after {
 	border-width: 3px;
 	left: 50%;
 	margin-left: -3px;
-}
-
-.upBtn:before, .dnBtn:before, .upManyBtn:before, .dnManyBtn:before {
-	border-width: 5px;
-	left: 50%;
-	margin-left: -5px;
-}
-
-.upManyBtn:after, .dnManyBtn:after {
-	border-width: 2px;
-	left: 50%;
-	margin-left: -2px;
 }
 
 .dnBtn:after, .dnManyBtn:after {


### PR DESCRIPTION
I made the quantity-adjust buttons just a little bigger to make them easier to target. Another user mentioned this being a problem, in issue #51.

BEFORE:
![image](https://cloud.githubusercontent.com/assets/11307282/7216918/be173d6a-e5de-11e4-8688-11c744997a96.png)

AFTER:
![image](https://cloud.githubusercontent.com/assets/11307282/7216919/c3acc6f0-e5de-11e4-9793-6de6c39c8104.png)
