### PR TITLE
Added hut fire event original strings

### DIFF
--- a/lang/adarkroom.pot
+++ b/lang/adarkroom.pot
@@ -3153,3 +3153,23 @@ msgstr ""
 #: script/events/setpieces.js:3565
 msgid "ripe for the picking."
 msgstr ""
+
+#: script/events/outside.js:74
+msgid "a fire rampages through one of the huts, destroying it."
+msgstr ""
+
+#: script/events/outside.js:75
+msgid "all residents in the hut perished in the fire."
+msgstr ""
+
+#: script/events/outside.js:77
+msgid "a fire has started"
+msgstr ""
+
+#: script/events/outside.js:87
+msgid "mourn"
+msgstr ""
+
+#: script/events/outside.js:88
+msgid "some villagers have died"
+msgstr ""


### PR DESCRIPTION
Although there was a previous commit referring to it, in POT file the strings related to "hut fire event" were not present.
I added them at the end of the file, with reference to original positions in Outside.js.
This way there is a reference for translators.
**And** this is separate from translation fix. :)