### PR TITLE
Languages table

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,16 +6,34 @@ a minimalist text adventure game for your browser
 
 [Click to play](http://adarkroom.doublespeakgames.com)
 
-Available | Languages
---------- | ---------
-[Chinese](http://adarkroom.doublespeakgames.com/?lang=zh_cn) | [English](http://adarkroom.doublespeakgames.com/?lang=en)
-[French](http://adarkroom.doublespeakgames.com/?lang=fr) | [German](http://adarkroom.doublespeakgames.com/?lang=de)
-[Italian](http://adarkroom.doublespeakgames.com/?lang=it) | [Japanese](http://adarkroom.doublespeakgames.com/?lang=ja)
-[Korean](http://adarkroom.doublespeakgames.com/?lang=ko) | [Norwegian](http://adarkroom.doublespeakgames.com/?lang=nb)
-[Polish](http://adarkroom.doublespeakgames.com/?lang=pl) | [Portuguese](http://adarkroom.doublespeakgames.com/?lang=pt)
-[Russian](http://adarkroom.doublespeakgames.com/?lang=ru) | [Spanish](http://adarkroom.doublespeakgames.com/?lang=es)
-[Swedish](http://adarkroom.doublespeakgames.com/?lang=sv) | [Turkish](http://adarkroom.doublespeakgames.com/?lang=tr)
-[Ukrainian](http://adarkroom.doublespeakgames.com/?lang=uk) | [Vietnamese] (http://adarkroom.doublespeakgames.com/?lang=vi)
+<table>
+<tr>
+<th colspan=2>Available Languages
+<tr>
+<td><a href="http://adarkroom.doublespeakgames.com/?lang=zh_cn">Chinese</a>
+<td><a href="http://adarkroom.doublespeakgames.com/?lang=en">English</a>
+<tr>
+<td><a href="http://adarkroom.doublespeakgames.com/?lang=fr">French</a>
+<td><a href="http://adarkroom.doublespeakgames.com/?lang=de">German</a>
+<tr>
+<td><a href="http://adarkroom.doublespeakgames.com/?lang=it">Italian</a>
+<td><a href="http://adarkroom.doublespeakgames.com/?lang=ja">Japanese</a>
+<tr>
+<td><a href="http://adarkroom.doublespeakgames.com/?lang=ko">Korean</a>
+<td><a href="http://adarkroom.doublespeakgames.com/?lang=nb">Norwegian</a>
+<tr>
+<td><a href="http://adarkroom.doublespeakgames.com/?lang=pl">Polish</a>
+<td><a href="http://adarkroom.doublespeakgames.com/?lang=pt">Portuguese</a>
+<tr>
+<td><a href="http://adarkroom.doublespeakgames.com/?lang=ru">Russian</a>
+<td><a href="http://adarkroom.doublespeakgames.com/?lang=es">Spanish</a>
+<tr>
+<td><a href="http://adarkroom.doublespeakgames.com/?lang=sv">Swedish</a>
+<td><a href="http://adarkroom.doublespeakgames.com/?lang=tr">Turkish</a>
+<tr>
+<td><a href="http://adarkroom.doublespeakgames.com/?lang=uk">Ukrainian</a>
+<td><a href="http://adarkroom.doublespeakgames.com/?lang=vi">Vietnamese</a>
+</table>
 
 or play the latest on [GitHub](http://doublespeakgames.github.io/adarkroom)
 


### PR DESCRIPTION
In a previous comment, it was said that actual markup is "cluttered" compared to Markdown. I don't think it was said with reference to my previous (ugly) wrapping, but nonetheless I corrected it (see source).
This is a possible solution for the split table heading issue. The fact is, MD tables are meant to be tables for real, and so they are made to show tabular data and not for layout.
Other possible solutions:
1. Use http://github.com/github/markup in order to extend Markdown with Mediawiki syntax (it allows attributes for cells). However it seems impractical.
2. Use simple text formatting and split the language lists into different blocks (e.g. according to continents, as there are several Asian languages (pay attention for Russian)
3. Keep it as-is and forget my issue altogether (it seems the most reasonable)