### PR TITLE
Changed size of languages menu (issue#413)

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -83,12 +83,12 @@ div#header {
 
 span.customSelectOptions {
 	margin: 0;
-	width: 80px;
+	width: 120px;
 }
 
 .customSelectOptions > ul {
 	max-height: 20px;
-	width: 80px;
+	width: 120px;
 	overflow: hidden;
 	-webkit-transition: max-height 1s;
 	transition: max-height 1s;
@@ -101,7 +101,7 @@ span.customSelectOptions {
 }
 
 .customSelectOptions > ul:hover {
-	max-height: 400px;
+	max-height: 450px;
 }
 
 .customSelectOptions > ul > li {


### PR DESCRIPTION
The Portuguese (brazil) option was too long and wrapping around to the next line, appearing right over the next language in the menu. Increased the width to accommodate in one line. Also increased the max height as the last language option wasn't visible. The menu can take one more language before needing to increase the height.