### PR TITLE
 Showing total in stores tooltip - Issue #170

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -182,6 +182,10 @@ div.row_val {
 	float: right;
 }
 
+div.total {
+	font-weight: bold;
+}
+
 /* Notifications */
 
 div#notifications {

--- a/script/room.js
+++ b/script/room.js
@@ -901,18 +901,19 @@ var Room = {
 							.addClass('row_val')
 							.text(Engine.getIncomeMsg(income.stores[store], income.delay))
 							.appendTo(tt);
-						totalIncome[store] = Number(totalIncome[store]) || 0;
-						totalIncome[store] += Number(income.stores[store]); 
+						if (totalIncome[store] === undefined || totalIncome[store]['income'] === undefined) {
+							totalIncome[store] = {};
+							totalIncome[store]['income'] = 0;
+						}
+						totalIncome[store]['income'] += Number(income.stores[store]);
+						totalIncome[store]['delay'] = income.delay;
 					}
 				}
 			}
 			if(tt.children().length > 0) {
-				var total = totalIncome[storeName];
-				if (total > 0) {
-					total = '+'+total;
-				}
+				var total = totalIncome[storeName]['income'];
 				$('<div>').addClass('total row_key').text(_('total')).appendTo(tt);
-				$('<div>').addClass('total row_val').text(''+total).appendTo(tt);
+				$('<div>').addClass('total row_val').text(Engine.getIncomeMsg(total, totalIncome[storeName]['delay'])).appendTo(tt);
 				tt.appendTo(el);
 			}
 		});

--- a/script/room.js
+++ b/script/room.js
@@ -885,6 +885,7 @@ var Room = {
 	
 	updateIncomeView: function() {
 		var stores = $('div#resources');
+		var totalIncome = {};
 		if(stores.length === 0 || typeof $SM.get('income') == 'undefined') return;
 		$('div.storeRow', stores).each(function(index, el) {
 			el = $(el);
@@ -900,10 +901,18 @@ var Room = {
 							.addClass('row_val')
 							.text(Engine.getIncomeMsg(income.stores[store], income.delay))
 							.appendTo(tt);
+						totalIncome[store] = Number(totalIncome[store]) || 0;
+						totalIncome[store] += Number(income.stores[store]); 
 					}
 				}
 			}
 			if(tt.children().length > 0) {
+				var total = totalIncome[storeName];
+				if (total > 0) {
+					total = '+'+total;
+				}
+				$('<div>').addClass('total row_key').text(_('total')).appendTo(tt);
+				$('<div>').addClass('total row_val').text(''+total).appendTo(tt);
 				tt.appendTo(el);
 			}
 		});


### PR DESCRIPTION
Added another row in the tooltip showing total calculation of resource yield.
![tooltip](https://cloud.githubusercontent.com/assets/4135198/8961330/e210e0be-3614-11e5-9ca4-7ab3f759d6e4.png)

*Note*
New string `total` needs to be localized.