### PR TITLE
Removed background-color for config lists.

### DIFF
--- a/css/dark.css
+++ b/css/dark.css
@@ -3,10 +3,6 @@ body {
 	color: #EEE;
 }
 
-/* .customSelectOptions > ul {
-	background-color: #272823;
-} */
-
 div.headerButton {
 	border-left: 1px solid #EEE;
 }

--- a/css/dark.css
+++ b/css/dark.css
@@ -3,9 +3,9 @@ body {
 	color: #EEE;
 }
 
-.customSelectOptions > ul {
+/* .customSelectOptions > ul {
 	background-color: #272823;
-}
+} */
 
 div.headerButton {
 	border-left: 1px solid #EEE;

--- a/css/main.css
+++ b/css/main.css
@@ -97,7 +97,7 @@ span.customSelectOptions {
 	bottom: 0;
 	position: absolute;
 	right: 0;
-	background-color: white;
+	/* background-color: white; */
 }
 
 .customSelectOptions > ul:hover {

--- a/css/main.css
+++ b/css/main.css
@@ -97,7 +97,6 @@ span.customSelectOptions {
 	bottom: 0;
 	position: absolute;
 	right: 0;
-	/* background-color: white; */
 }
 
 .customSelectOptions > ul:hover {


### PR DESCRIPTION
Background colors for unordered list in options were set to match body.
This created a problem during and after the space game when the body and
text were inverted, but the ul was not. See Issue #432.

Tried this via Chrome's dev tools while at the affected screen in dark
theme, and it seemed to work. No further testing.