### PR TITLE
Proposed fix for #506

### DIFF
--- a/script/state_manager.js
+++ b/script/state_manager.js
@@ -362,21 +362,19 @@ var StateManager = {
 				if(income.timeLeft <= 0) {
 					Engine.log('collection income from ' + source);
 					if(source == 'thieves') $SM.addStolen(income.stores);
-
-					var cost = income.stores;
-					var ok = true;
-					if (source != 'thieves') {
+					else {
+						var ok = true;
+						var cost = income.stores;
 						for (var k in cost) {
 							var have = $SM.get('stores["' + k + '"]', true);
 							if (have + cost[k] < 0) {
 								ok = false;
+								$SM.add('game.workers["'+ source +'"]', -1);
+								Engine.log('a ' + source + ' left due to lack of resources');
 								break;
 							}
 						}
-					}
-
-					if(ok){
-						$SM.addM('stores', income.stores, true);
+						if (ok) $SM.addM('stores', income.stores, true);
 					}
 					changed = true;
 					if(typeof income.delay == 'number') {

--- a/script/state_manager.js
+++ b/script/state_manager.js
@@ -361,21 +361,21 @@ var StateManager = {
 
 				if(income.timeLeft <= 0) {
 					Engine.log('collection income from ' + source);
+					var ok = true;
 					if(source == 'thieves') $SM.addStolen(income.stores);
 					else {
-						var ok = true;
 						var cost = income.stores;
 						for (var k in cost) {
 							var have = $SM.get('stores["' + k + '"]', true);
 							if (have + cost[k] < 0) {
 								ok = false;
 								$SM.add('game.workers["'+ source +'"]', -1);
-								Engine.log('a ' + source + ' left due to lack of resources');
+								Engine.log('one ' + source + ' left due to lack of resources');
 								break;
 							}
 						}
-						if (ok) $SM.addM('stores', income.stores, true);
 					}
+					if (ok) $SM.addM('stores', income.stores, true);
 					changed = true;
 					if(typeof income.delay == 'number') {
 						income.timeLeft = income.delay;


### PR DESCRIPTION
Issue #506 arises because the game aggregates all costs for a given resource into one number, so it is not possible to fulfill the cost requirements of only some of the workers. My proposed fix is to have workers slowly leave their jobs when they do not have enough resources.

For example, suppose your tanners don't have enough furs. With this modification, they will leave one by one (to become gatherers) until the cost in furs is satisfiable.

With this change, it is still possible to increase the number of workers on a given task to unsustainable levels; once the task is complete they will self-adjust back down to sustainable numbers.