### PR TITLE
Added the option to close the 'get app' dialog

### DIFF
--- a/script/engine.js
+++ b/script/engine.js
@@ -423,6 +423,10 @@
 								onChoose: function() {
 									window.open('https://play.google.com/store/apps/details?id=com.yourcompany.adarkroom');
 								}
+							},
+							'close': {
+								text: _('close'),
+								nextScene: 'end'
 							}
 						}
 					}


### PR DESCRIPTION
One couldn't close the 'get app' dialog without refreshing or manipulating the website via the "Inspect"-tool in the browser.