### PR TITLE
bug -- doubleTime is harmful during space.js, so disable it

### DIFF
--- a/script/space.js
+++ b/script/space.js
@@ -166,7 +166,7 @@ var Space = {
 			}
 			
 			if(!Space.done) {
-				Engine.setTimeout(Space.createAsteroid, 1000 - (Space.altitude * 10));
+				Engine.setTimeout(Space.createAsteroid, 1000 - (Space.altitude * 10), true);
 			}
 		}
 	},
@@ -266,7 +266,7 @@ var Space = {
 				$('#spacePanel, .menu, select.menuBtn').animate({color: '#272823'}, 500, 'linear');
 			else
 				$('#spacePanel, .menu, select.menuBtn').animate({color: 'white'}, 500, 'linear');
-		}, Space.FTB_SPEED / 2);
+		}, Space.FTB_SPEED / 2, true);
 		
 		Space.createAsteroid();
 	},


### PR DESCRIPTION
The bug makes more asteroids on the screen at once.  It's especially evident if you modify doubleTime to be, say, 32x speed, but is still a problem at 2x speed.

The second line in this pull request is related, but regards a visual defect that makes it almost impossible  to see during part of liftoff when doubleTime is enabled.  (again, it's more evident at 32x speed)