### PR TITLE
Engine._debug sped up

### DIFF
--- a/script/Button.js
+++ b/script/Button.js
@@ -68,6 +68,9 @@ var Button = {
 
 	cooldown: function(btn, option) {
 		var cd = btn.data("cooldown");
+        if (Engine.options.doubleTime && Engine._debug) {
+            cd = cd > 1 ? 1 : cd;
+        }
 		var id = 'cooldown.'+ btn.attr('id');
 		if(cd > 0) {
 			if(typeof option == 'number') {

--- a/script/engine.js
+++ b/script/engine.js
@@ -785,7 +785,7 @@
 		setInterval: function(callback, interval, skipDouble){
 			if( Engine.options.doubleTime && !skipDouble ){
 				Engine.log('Double time, cutting interval in half');
-				interval /= 2;
+				interval /= Engine._debug ? 32 : 2;
 			}
 
 			return setInterval(callback, interval);
@@ -796,7 +796,7 @@
 
 			if( Engine.options.doubleTime && !skipDouble ){
 				Engine.log('Double time, cutting timeout in half');
-				timeout /= 2;
+				timeout /= Engine._debug ? 32 : 2;
 			}
 
 			return setTimeout(callback, timeout);

--- a/script/events.js
+++ b/script/events.js
@@ -137,7 +137,7 @@ var Events = {
 		Events.setHeal(healBtns);
 
 		// Set up the enemy attack timer
-		Events._enemyAttackTimer = Engine.setInterval(Events.enemyAttack, scene.attackDelay * 1000);
+		Events._enemyAttackTimer = Engine.setInterval(Events.enemyAttack, scene.attackDelay * 1000, Engine._debug);
 	},
 
 	setPause: function(btn, state){
@@ -1076,7 +1076,7 @@ var Events = {
 		var nextEvent = Math.floor(Math.random()*(Events._EVENT_TIME_RANGE[1] - Events._EVENT_TIME_RANGE[0])) + Events._EVENT_TIME_RANGE[0];
 		if(scale > 0) { nextEvent *= scale; }
 		Engine.log('next event scheduled in ' + nextEvent + ' minutes');
-		Events._eventTimeout = Engine.setTimeout(Events.triggerEvent, nextEvent * 60 * 1000);
+		Events._eventTimeout = Engine.setTimeout(Events.triggerEvent, nextEvent * 60 * 1000, Engine._debug);
 	},
 
 	endEvent: function() {

--- a/script/space.js
+++ b/script/space.js
@@ -166,7 +166,7 @@ var Space = {
 			}
 			
 			if(!Space.done) {
-				Engine.setTimeout(Space.createAsteroid, 1000 - (Space.altitude * 10));
+				Engine.setTimeout(Space.createAsteroid, 1000 - (Space.altitude * 10), true);
 			}
 		}
 	},
@@ -266,7 +266,7 @@ var Space = {
 				$('#spacePanel, .menu, select.menuBtn').animate({color: '#272823'}, 500, 'linear');
 			else
 				$('#spacePanel, .menu, select.menuBtn').animate({color: 'white'}, 500, 'linear');
-		}, Space.FTB_SPEED / 2);
+		}, Space.FTB_SPEED / 2, true);
 		
 		Space.createAsteroid();
 	},

--- a/script/world.js
+++ b/script/world.js
@@ -607,6 +607,7 @@ var World = {
 	lightMap: function(x, y, mask) {
 		var r = World.LIGHT_RADIUS;
 		r *= $SM.hasPerk('scout') ? 2 : 1;
+		r *= Engine._debug ? 4 : 1;					// Engine._debug is supposed to speed the game up.  Exploring the map isn't fast.
 		World.uncoverMap(x, y, r, mask);
 		return mask;
 	},


### PR DESCRIPTION
Want to play the game fast?  Like really fast?  Sure, you could cheat and give yourself 999999 steel and alien alloy.  OR you could use this patch and experience ALL of the game mechanics, just sped up.

This pull request has the following specific effects when Engine._debug is enabled:

* DoubleTime is 32x speed instead of 2x.
* Button cooldown is almost instant.
* When exploring the map, the visible area is 4x the normal size, just to make exploration faster.