### PR TITLE
Increase cured meat cost of mined ores, to account for travel time of…

### DIFF
--- a/script/outside.js
+++ b/script/outside.js
@@ -55,7 +55,7 @@ var Outside = {
 			name: _('iron miner'),
 			delay: 10,
 			stores: {
-				'cured meat': -1,
+				'cured meat': -6,
 				'iron': 1
 			}
 		},
@@ -63,7 +63,7 @@ var Outside = {
 			name: _('coal miner'),
 			delay: 10,
 			stores: {
-				'cured meat': -1,
+				'cured meat': -11,
 				'coal': 1
 			}
 		},
@@ -71,7 +71,7 @@ var Outside = {
 			name: _('sulphur miner'),
 			delay: 10,
 			stores: {
-				'cured meat': -1,
+				'cured meat': -21,
 				'sulphur': 1
 			}
 		},


### PR DESCRIPTION
The idea here is simple:
1. Consistency. It takes food to travel out to the mine, harvest the ores, and bring the ores back. This increases the food cost.
2. Consumption of raw meat. There is a huge oversupply of meat from hunting, and this will consume it.
3. Without this, the relatively short time of iron/steel/suphur is just strange -- you very quickly have mined all you need, and don't worry about it again. Now it will take noticeable time, and if you need to produce a large, ongoing supply of bullets, you will quickly feel it. This is an intentional ... difficulty increase? Time cost? Worker tie-down? Something.