### PR TITLE
Change content vertical size to 1100px. This makes the window fit whe…

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -56,7 +56,7 @@ div#saveNotify {
 div#content {
 	position: relative;
 	overflow: hidden;
-	height: 700px;
+	height: 1100px;
 }
 
 div#header {
@@ -163,7 +163,7 @@ div#outerSlider > div {
 	position: relative;
 	float: left;
 	width: 700px;
-	height: 700px;
+	height: 1100px;
 	overflow: hidden;
 }
 


### PR DESCRIPTION
This is not a "perfect fix". This just make the world map visible.

Issues: 
1. Arrows will move the wanderer AND scroll the screen. 
This seriously affects the space section.

2. If you are exploring south, events (combat) will show up at the top, and you won't see it without scrolling up. This really affects exploring the south half of the world.

Yes, this means I restart until I find a compass pointing northwards. 

3. If the font size is small enough that the whole thing fits without scrolling, then the fonts are too small to be readable.
