### PR TITLE
Increase food cost of ores

### DIFF
--- a/script/outside.js
+++ b/script/outside.js
@@ -47,7 +47,7 @@ var Outside = {
 			delay: 10,
 			stores: {
 				'meat': -5,
-				'wood': -5,
+				'wood': -1,
 				'cured meat': 1
 			}
 		},

--- a/script/outside.js
+++ b/script/outside.js
@@ -55,7 +55,7 @@ var Outside = {
 			name: _('iron miner'),
 			delay: 10,
 			stores: {
-				'cured meat': -1,
+				'cured meat': -6,
 				'iron': 1
 			}
 		},
@@ -63,7 +63,7 @@ var Outside = {
 			name: _('coal miner'),
 			delay: 10,
 			stores: {
-				'cured meat': -1,
+				'cured meat': -11,
 				'coal': 1
 			}
 		},
@@ -71,7 +71,7 @@ var Outside = {
 			name: _('sulphur miner'),
 			delay: 10,
 			stores: {
-				'cured meat': -1,
+				'cured meat': -21,
 				'sulphur': 1
 			}
 		},


### PR DESCRIPTION
Reduced the wood cost of cured meat down to 1. This makes the wood cost of the increased meat manageable.

NB: My play style is very heavy on hunting for trade. If you are not a "need fur for trade" person, the meat cost might be too high.

This is manageable for iron.
Sulphur is not yet tested (not yet able to clear that mine).