### PR TITLE
jshint warning ('cur' is already defined)

### DIFF
--- a/script/world.js
+++ b/script/world.js
@@ -774,12 +774,13 @@ var World = {
 
 		var chances = {};
 		var nonSticky = 1;
+		var cur;
 		for(var i in adjacent) {
 			if(adjacent[i] == World.TILE.VILLAGE) {
 				// Village must be in a forest to maintain thematic consistency, yo.
 				return World.TILE.FOREST;
 			} else if(typeof adjacent[i] == 'string') {
-				var cur = chances[adjacent[i]];
+				cur = chances[adjacent[i]];
 				cur = typeof cur == 'number' ? cur : 0;
 				chances[adjacent[i]] = cur + World.STICKINESS;
 				nonSticky -= World.STICKINESS;
@@ -788,7 +789,7 @@ var World = {
 		for(var t in World.TILE) {
 			var tile = World.TILE[t];
 			if(World.isTerrain(tile)) {
-				var cur = chances[tile];
+				cur = chances[tile];
 				cur = typeof cur == 'number' ? cur : 0;
 				cur += World.TILE_PROBS[tile] * nonSticky;
 				chances[tile] = cur;


### PR DESCRIPTION
The "cur" variable is defined twice in each for loop.
So I pulled out the definition part of the "cur" variable.