### PR TITLE
Fix buying maps causing crashes #515

### DIFF
--- a/script/world.js
+++ b/script/world.js
@@ -645,8 +645,8 @@ var World = {
 		if(!World.seenAll){
 			var x,y,mask = $SM.get('game.world.mask');
 			do {
-				x = Math.floor(Math.random() * (World.RADIUS * 2) + 1);
-				y = Math.floor(Math.random() * (World.RADIUS * 2) + 1);
+				x = Math.floor(Math.random() * (World.RADIUS * 2 + 1));
+				y = Math.floor(Math.random() * (World.RADIUS * 2 + 1));
 			} while (mask[x][y]);
 			World.uncoverMap(x, y, 5, mask);
 		}


### PR DESCRIPTION
Fixes the applyMap function that could not uncover single points of map on the top and left borders and thus was causing an infinite loop crash when buying enough maps.