### PR TITLE
resolve loadAudioFile error when query string in URL

### DIFF
--- a/script/audio.js
+++ b/script/audio.js
@@ -204,7 +204,11 @@ var AudioEngine = {
     },
     loadAudioFile: function (src) {
         if (src.indexOf('http') === -1) {
-            src = window.location + src;
+            var path = window.location.protocol + '//' + window.location.hostname + (window.location.port ?(':' + window.location.port) : '') + window.location.pathname;
+            if(path.endsWith('index.html')){
+                path = path.slice(0, - 10); 
+            }
+            src = path + src;
         }
         if (AudioEngine.AUDIO_BUFFER_CACHE[src]) {
             return new Promise(function (resolve, reject) {


### PR DESCRIPTION
When the URL contains a query string (e.g., "?lang=zh_cn") or is accessed with index.html, loadAudioFile fails to load the audio files (#694 ). The issue has been resolved by removing that from the URL before concatenating `src` link.
It seems that this project supports IE9 and above, so we use the method of concatenating to construct the origin instead of relying on `window.location.origin`.