### PR TITLE
Fix spelling mistake

### DIFF
--- a/lang/adarkroom.pot
+++ b/lang/adarkroom.pot
@@ -2666,7 +2666,7 @@ msgid "the footsteps stop."
 msgstr ""
 
 #: script/events/setpieces.js:920
-msgid "another beast, draw by the noise, leaps out of a copse of trees."
+msgid "another beast, drawn by the noise, leaps out of a copse of trees."
 msgstr ""
 
 #: script/events/setpieces.js:936

--- a/lang/cs/strings.po
+++ b/lang/cs/strings.po
@@ -2701,7 +2701,7 @@ msgid "the footsteps stop."
 msgstr "kroky ustaly."
 
 #: script/events/setpieces.js:920
-msgid "another beast, draw by the noise, leaps out of a copse of trees."
+msgid "another beast, drawn by the noise, leaps out of a copse of trees."
 msgstr "další příšera, kterou přilákal hluk, vyskakuje z mlází stromů."
 
 #: script/events/setpieces.js:936

--- a/lang/de/strings.po
+++ b/lang/de/strings.po
@@ -1531,7 +1531,7 @@ msgid "the footsteps stop."
 msgstr "die schritte verstummen."
 
 #: script/events/setpieces.js:917
-msgid "another beast, draw by the noise, leaps out of a copse of trees."
+msgid "another beast, drawn by the noise, leaps out of a copse of trees."
 msgstr "noch eine bestie, durch den lärm angelockt, kommt rasch näher."
 
 #: script/events/setpieces.js:933

--- a/lang/el/strings.po
+++ b/lang/el/strings.po
@@ -2707,7 +2707,7 @@ msgid "the footsteps stop."
 msgstr "τα βήματα σταματούν."
 
 #: script/events/setpieces.js:917
-msgid "another beast, draw by the noise, leaps out of a copse of trees."
+msgid "another beast, drawn by the noise, leaps out of a copse of trees."
 msgstr ""
 "ένα ακόμα θηρίο, ακολουθώντας το θόρυβο, ξεπηδάει από ένα δασάκι των δέντρων."
 

--- a/lang/eo/strings.po
+++ b/lang/eo/strings.po
@@ -2565,7 +2565,7 @@ msgid "the footsteps stop."
 msgstr "la piedpaŝoj ĉesas."
 
 #: script/events/setpieces.js:917
-msgid "another beast, draw by the noise, leaps out of a copse of trees."
+msgid "another beast, drawn by the noise, leaps out of a copse of trees."
 msgstr "plia besto, ellogite pro la bruo, saltegas el areto da arboj."
 
 #: script/events/setpieces.js:933

--- a/lang/es/strings.po
+++ b/lang/es/strings.po
@@ -2600,7 +2600,7 @@ msgid "the footsteps stop."
 msgstr "los pasos se detienen."
 
 #: script/events/setpieces.js:917
-msgid "another beast, draw by the noise, leaps out of a copse of trees."
+msgid "another beast, drawn by the noise, leaps out of a copse of trees."
 msgstr "otra bestia, atraida por el ruido, salta de un bosquecillo de árboles."
 
 #: script/events/setpieces.js:933

--- a/lang/fr/strings.po
+++ b/lang/fr/strings.po
@@ -1557,7 +1557,7 @@ msgid "the footsteps stop."
 msgstr "les pas s'arrêtent."
 
 #: ../../script/events/setpieces.js:917
-msgid "another beast, draw by the noise, leaps out of a copse of trees."
+msgid "another beast, drawn by the noise, leaps out of a copse of trees."
 msgstr "une autre bête, attirée par le bruit, surgit d'un bosquet."
 
 #: ../../script/events/setpieces.js:933

--- a/lang/gl/strings.po
+++ b/lang/gl/strings.po
@@ -2662,7 +2662,7 @@ msgid "the footsteps stop."
 msgstr "os pasos páranse."
 
 #: script/events/setpieces.js:917
-msgid "another beast, draw by the noise, leaps out of a copse of trees."
+msgid "another beast, drawn by the noise, leaps out of a copse of trees."
 msgstr ""
 "outra besta, atraída polo ruído, aparece de repnte nun grupo de árbores."
 

--- a/lang/id/strings.po
+++ b/lang/id/strings.po
@@ -2781,7 +2781,7 @@ msgid "the footsteps stop."
 msgstr "langkah kaki berhenti."
 
 #: script/events/setpieces.js:917
-msgid "another beast, draw by the noise, leaps out of a copse of trees."
+msgid "another beast, drawn by the noise, leaps out of a copse of trees."
 msgstr ""
 "binatang lain, terpancing oleh keributan, melompat keluar dari pepohonan "
 "mati."

--- a/lang/it/strings.po
+++ b/lang/it/strings.po
@@ -2614,7 +2614,7 @@ msgid "the footsteps stop."
 msgstr "i passi si arrestano."
 
 #: script/events/setpieces.js:917
-msgid "another beast, draw by the noise, leaps out of a copse of trees."
+msgid "another beast, drawn by the noise, leaps out of a copse of trees."
 msgstr "un altro animale, attratto dal rumore, emerge da un gruppo di alberi."
 
 #: script/events/setpieces.js:933

--- a/lang/ja/strings.po
+++ b/lang/ja/strings.po
@@ -2561,7 +2561,7 @@ msgid "the footsteps stop."
 msgstr "足音が止まった。"
 
 #: script/events/setpieces.js:917
-msgid "another beast, draw by the noise, leaps out of a copse of trees."
+msgid "another beast, drawn by the noise, leaps out of a copse of trees."
 msgstr "音に引き寄せられた別の獣が雑木林から跳びだしてきた。"
 
 #: script/events/setpieces.js:933

--- a/lang/ko/strings.po
+++ b/lang/ko/strings.po
@@ -2550,7 +2550,7 @@ msgid "the footsteps stop."
 msgstr "발자국 소리는 멈춘다."
 
 #: script/events/setpieces.js:917
-msgid "another beast, draw by the noise, leaps out of a copse of trees."
+msgid "another beast, drawn by the noise, leaps out of a copse of trees."
 msgstr "다른 동물 한 마리가 소리에 이끌려, 나무를 박차고 펄쩍 뛴다."
 
 #: script/events/setpieces.js:933

--- a/lang/lt_LT/strings.po
+++ b/lang/lt_LT/strings.po
@@ -2562,7 +2562,7 @@ msgid "the footsteps stop."
 msgstr "žingsniai sustoja."
 
 #: script/events/setpieces.js:917
-msgid "another beast, draw by the noise, leaps out of a copse of trees."
+msgid "another beast, drawn by the noise, leaps out of a copse of trees."
 msgstr "išgirdęs triukšmą, iš brūzgyno iššoka dar vienas žvėris."
 
 #: script/events/setpieces.js:933

--- a/lang/lv/strings.po
+++ b/lang/lv/strings.po
@@ -2575,7 +2575,7 @@ msgid "the footsteps stop."
 msgstr "soļi apstājas."
 
 #: script/events/setpieces.js:917
-msgid "another beast, draw by the noise, leaps out of a copse of trees."
+msgid "another beast, drawn by the noise, leaps out of a copse of trees."
 msgstr "trokšņa piesaistīts, no mežāja pēkšņi uzklūp vēl viens zvērs."
 
 #: script/events/setpieces.js:933

--- a/lang/nb/strings.po
+++ b/lang/nb/strings.po
@@ -2577,7 +2577,7 @@ msgid "the footsteps stop."
 msgstr "lyden av føtter stopper."
 
 #: script/events/setpieces.js:917
-msgid "another beast, draw by the noise, leaps out of a copse of trees."
+msgid "another beast, drawn by the noise, leaps out of a copse of trees."
 msgstr "et annet beist, tiltrukket av lyden, hopper ut av en klynge trær."
 
 #: script/events/setpieces.js:933

--- a/lang/pl/strings.po
+++ b/lang/pl/strings.po
@@ -2582,7 +2582,7 @@ msgid "the footsteps stop."
 msgstr "kroki cichną."
 
 #: script/events/setpieces.js:917
-msgid "another beast, draw by the noise, leaps out of a copse of trees."
+msgid "another beast, drawn by the noise, leaps out of a copse of trees."
 msgstr "jeszcze jedna bestia, sprowokowana przez hałas, wyskakuje z zagajnika."
 
 #: script/events/setpieces.js:933

--- a/lang/pt/strings.po
+++ b/lang/pt/strings.po
@@ -2594,7 +2594,7 @@ msgid "the footsteps stop."
 msgstr "os passos parar."
 
 #: script/events/setpieces.js:917
-msgid "another beast, draw by the noise, leaps out of a copse of trees."
+msgid "another beast, drawn by the noise, leaps out of a copse of trees."
 msgstr "outra besta, empate com o barulho, salta de um bosque de árvores."
 
 #: script/events/setpieces.js:933

--- a/lang/pt_br/strings.po
+++ b/lang/pt_br/strings.po
@@ -2545,7 +2545,7 @@ msgid "the footsteps stop."
 msgstr "os passos param."
 
 #: script/events/setpieces.js:917
-msgid "another beast, draw by the noise, leaps out of a copse of trees."
+msgid "another beast, drawn by the noise, leaps out of a copse of trees."
 msgstr "outra fera, chamada pelo barulho, salta de árvoresde de um bosque."
 
 #: script/events/setpieces.js:933

--- a/lang/ru/strings.po
+++ b/lang/ru/strings.po
@@ -1532,7 +1532,7 @@ msgid "the footsteps stop."
 msgstr "шаги прекратились."
 
 #: ../../script/events/setpieces.js:917
-msgid "another beast, draw by the noise, leaps out of a copse of trees."
+msgid "another beast, drawn by the noise, leaps out of a copse of trees."
 msgstr "еще один зверь, услышав шум, выпрыгивает из-за деревьев."
 
 #: ../../script/events/setpieces.js:933

--- a/lang/sv/strings.po
+++ b/lang/sv/strings.po
@@ -2578,7 +2578,7 @@ msgid "the footsteps stop."
 msgstr "ljudet tystnar."
 
 #: script/events/setpieces.js:917
-msgid "another beast, draw by the noise, leaps out of a copse of trees."
+msgid "another beast, drawn by the noise, leaps out of a copse of trees."
 msgstr ""
 
 #: script/events/setpieces.js:933

--- a/lang/th/strings.po
+++ b/lang/th/strings.po
@@ -2685,7 +2685,7 @@ msgid "the footsteps stop."
 msgstr "เสียงฝีเท้าสงบลง"
 
 #: script/events/setpieces.js:917
-msgid "another beast, draw by the noise, leaps out of a copse of trees."
+msgid "another beast, drawn by the noise, leaps out of a copse of trees."
 msgstr "สัตว์ป่าอีกตัวที่ถูกดึงดูดมาด้วยเสียง โจนออกมาจากโคนต้นไม้"
 
 #: script/events/setpieces.js:933

--- a/lang/tr/strings.po
+++ b/lang/tr/strings.po
@@ -1535,7 +1535,7 @@ msgid "the footsteps stop."
 msgstr "sesler kesildi."
 
 #: ../../script/events/setpieces.js:917
-msgid "another beast, draw by the noise, leaps out of a copse of trees."
+msgid "another beast, drawn by the noise, leaps out of a copse of trees."
 msgstr ""
 
 #: ../../script/events/setpieces.js:933

--- a/lang/uk/strings.po
+++ b/lang/uk/strings.po
@@ -1549,7 +1549,7 @@ msgid "the footsteps stop."
 msgstr "кроки зупинились."
 
 #: ../../script/events/setpieces.js:917
-msgid "another beast, draw by the noise, leaps out of a copse of trees."
+msgid "another beast, drawn by the noise, leaps out of a copse of trees."
 msgstr "ще один звір, почувши шум, виплигнув з-за дерев."
 
 #: ../../script/events/setpieces.js:933

--- a/lang/vi/strings.po
+++ b/lang/vi/strings.po
@@ -2573,7 +2573,7 @@ msgid "the footsteps stop."
 msgstr "tiếng bước chân ngừng lại."
 
 #: script/events/setpieces.js:917
-msgid "another beast, draw by the noise, leaps out of a copse of trees."
+msgid "another beast, drawn by the noise, leaps out of a copse of trees."
 msgstr "một con thú khác, rút lại bởi tiếng ồn, nhảy ra khỏi một cây bụi rậm."
 
 #: script/events/setpieces.js:933

--- a/lang/zh_cn/strings.po
+++ b/lang/zh_cn/strings.po
@@ -2615,7 +2615,7 @@ msgid "the footsteps stop."
 msgstr "脚步声停止了"
 
 #: script/events/setpieces.js:917
-msgid "another beast, draw by the noise, leaps out of a copse of trees."
+msgid "another beast, drawn by the noise, leaps out of a copse of trees."
 msgstr "另一只野兽被声音吸引，跳出了树丛"
 
 #: script/events/setpieces.js:933

--- a/lang/zh_tw/strings.po
+++ b/lang/zh_tw/strings.po
@@ -1517,7 +1517,7 @@ msgid "the footsteps stop."
 msgstr "安靜下來了"
 
 #: ../../script/events/setpieces.js:917
-msgid "another beast, draw by the noise, leaps out of a copse of trees."
+msgid "another beast, drawn by the noise, leaps out of a copse of trees."
 msgstr ""
 
 #: ../../script/events/setpieces.js:933

--- a/script/events/setpieces.js
+++ b/script/events/setpieces.js
@@ -917,7 +917,7 @@ Events.Setpieces = {
 						chance: 1
 					}
 				},
-				notification: _('another beast, draw by the noise, leaps out of a copse of trees.'),
+				notification: _('another beast, drawn by the noise, leaps out of a copse of trees.'),
 				buttons: {
 					'continue': {
 						text: _('continue'),


### PR DESCRIPTION
For each location where the string "another beast, draw by the noise, leaps out of a copse of trees." is located, "draw" is replaced with "drawn".  This is changed in all strings.po for all languages, as well as setpieces.js and adarkroom.pot.

This is because "drawn" is the past participle of "draw".  The phrase "drawn by the noise" functions as an adjectival phrase modifying the noun "beast." It indicates that the beast is attracted or compelled to leap out of the copse of trees due to the noise, hence requiring the past participle.

I also just really love ADR and The Ensign and wanted to contribute in a way I know how.

The line in game:
![ADR Line](https://github.com/doublespeakgames/adarkroom/assets/87635341/119cb680-fefe-4919-a851-a3fe5b4bf77e)
