### PR TITLE
Disruptor item typo: somtimes -> sometimes

### DIFF
--- a/script/fabricator.js
+++ b/script/fabricator.js
@@ -45,7 +45,7 @@ const Fabricator = {
       name: _('disruptor'),
       type: 'weapon',
       blueprintRequired: true,
-      buildMsg: _("somtimes it is best not to fight."),
+      buildMsg: _("sometimes it is best not to fight."),
       cost: () => ({
         'alien alloy': 1
       })


### PR DESCRIPTION
this fixes a typo for the disruptor item.
<img width="241" alt="Screenshot 2023-12-15 at 21 52 41" src="https://github.com/doublespeakgames/adarkroom/assets/4966687/04fd7286-2f46-4a05-bf15-006befbc13f6">
<img width="707" alt="Screenshot 2023-12-15 at 21 57 08" src="https://github.com/doublespeakgames/adarkroom/assets/4966687/f752e144-b03f-497a-9105-2c1502508275">

the typo is on the line:
```
script/fabricator.js:48:      buildMsg: _("somtimes it is best not to fight."),
```