### PR TITLE
disintigrate -> disintegrate (plasma rifle) typo fix

### DIFF
--- a/script/world.js
+++ b/script/world.js
@@ -102,7 +102,7 @@ var World = {
       cost: { 'bolas': 1 }
     },
     'plasma rifle': {
-      verb: _('disintigrate'),
+      verb: _('disintegrate'),
       type: 'ranged',
       damage: 12,
       cooldown: 1,


### PR DESCRIPTION
@Continuities this fixes the plasma rifle typo:
![image](https://github.com/doublespeakgames/adarkroom/assets/4966687/2fd952b4-67c4-44a5-a618-4eb7047ea287)
<img width="703" alt="Screenshot 2023-12-15 at 22 37 05" src="https://github.com/doublespeakgames/adarkroom/assets/4966687/e562f59f-5291-4d94-820c-6ce556358865">
 in world.js on row 105:
```
script/world.js:105:      verb: _('disintigrate'),
```
