### PR TITLE
feat: Add emoji flair to the game

### DIFF
--- a/lang/adarkroom.pot
+++ b/lang/adarkroom.pot
@@ -688,35 +688,35 @@ msgid "not enough meat"
 msgstr ""
 
 #: script/localization.js:58
-msgid "the compass points east"
+msgid "the compass points east 👉"
 msgstr ""
 
 #: script/localization.js:59
-msgid "the compass points west"
+msgid "the compass points west 👈"
 msgstr ""
 
 #: script/localization.js:60
-msgid "the compass points north"
+msgid "the compass points north 👆"
 msgstr ""
 
 #: script/localization.js:61
-msgid "the compass points south"
+msgid "the compass points south 👇"
 msgstr ""
 
 #: script/localization.js:62
-msgid "the compass points northeast"
+msgid "the compass points northeast ↗️"
 msgstr ""
 
 #: script/localization.js:63
-msgid "the compass points northwest"
+msgid "the compass points northwest ↖️"
 msgstr ""
 
 #: script/localization.js:64
-msgid "the compass points southeast"
+msgid "the compass points southeast ↘️"
 msgstr ""
 
 #: script/localization.js:65
-msgid "the compass points southwest"
+msgid "the compass points southwest ↙️"
 msgstr ""
 
 #: script/outside.js:5
@@ -1160,43 +1160,43 @@ msgid ""
 msgstr ""
 
 #: script/room.js:617
-msgid "freezing"
+msgid "freezing 🥶"
 msgstr ""
 
 #: script/room.js:618
-msgid "cold"
+msgid "cold 🧊"
 msgstr ""
 
 #: script/room.js:619
-msgid "mild"
+msgid "mild 🙂"
 msgstr ""
 
 #: script/room.js:620
-msgid "warm"
+msgid "warm 😊"
 msgstr ""
 
 #: script/room.js:621
-msgid "hot"
+msgid "hot 🥵"
 msgstr ""
 
 #: script/room.js:633
-msgid "dead"
+msgid "dead 💀"
 msgstr ""
 
 #: script/room.js:634
-msgid "smoldering"
+msgid "smoldering 🌫️"
 msgstr ""
 
 #: script/room.js:635
-msgid "flickering"
+msgid "flickering ✨"
 msgstr ""
 
 #: script/room.js:636
-msgid "burning"
+msgid "burning 🔥"
 msgstr ""
 
 #: script/room.js:637
-msgid "roaring"
+msgid "roaring 🔥🔥🔥"
 msgstr ""
 
 #: script/room.js:641
@@ -1208,11 +1208,11 @@ msgid "not enough wood to get the fire going"
 msgstr ""
 
 #: script/room.js:693
-msgid "the wood has run out"
+msgid "the wood has run out 🪵"
 msgstr ""
 
 #: script/room.js:714
-msgid "the light from the fire spills from the windows, out into the dark"
+msgid "the light from the fire spills from the windows, out into the dark ✨"
 msgstr ""
 
 #: script/room.js:732

--- a/script/room.js
+++ b/script/room.js
@@ -11,7 +11,7 @@ var Room = {
 	buttons: {},
 	Craftables: {
 		'trap': {
-			name: _('trap'),
+			name: _('trap 🪤'),
 			button: null,
 			maximum: 10,
 			availableMsg: _('builder says she can make traps to catch any creatures might still be alive out there'),
@@ -27,7 +27,7 @@ var Room = {
 			audio: AudioLibrary.BUILD_TRAP
 		},
 		'cart': {
-			name: _('cart'),
+			name: _('cart 🛒'),
 			button: null,
 			maximum: 1,
 			availableMsg: _('builder says she can make a cart for carrying wood'),
@@ -41,7 +41,7 @@ var Room = {
 			audio: AudioLibrary.BUILD_CART
 		},
 		'hut': {
-			name: _('hut'),
+			name: _('hut 🛖'),
 			button: null,
 			maximum: 20,
 			availableMsg: _("builder says there are more wanderers. says they'll work, too."),
@@ -57,7 +57,7 @@ var Room = {
 			audio: AudioLibrary.BUILD_HUT
 		},
 		'lodge': {
-			name: _('lodge'),
+			name: _('lodge 🏠'),
 			button: null,
 			maximum: 1,
 			availableMsg: _('villagers could help hunt, given the means'),
@@ -73,7 +73,7 @@ var Room = {
 			audio: AudioLibrary.BUILD_LODGE
 		},
 		'trading post': {
-			name: _('trading post'),
+			name: _('trading post 🏪'),
 			button: null,
 			maximum: 1,
 			availableMsg: _("a trading post would make commerce easier"),
@@ -88,7 +88,7 @@ var Room = {
 			audio: AudioLibrary.BUILD_TRADING_POST
 		},
 		'tannery': {
-			name: _('tannery'),
+			name: _('tannery 🏭'),
 			button: null,
 			maximum: 1,
 			availableMsg: _("builder says leather could be useful. says the villagers could make it."),
@@ -103,7 +103,7 @@ var Room = {
 			audio: AudioLibrary.BUILD_TANNERY
 		},
 		'smokehouse': {
-			name: _('smokehouse'),
+			name: _('smokehouse 💨'),
 			button: null,
 			maximum: 1,
 			availableMsg: _("should cure the meat, or it'll spoil. builder says she can fix something up."),
@@ -118,7 +118,7 @@ var Room = {
 			audio: AudioLibrary.BUILD_SMOKEHOUSE
 		},
 		'workshop': {
-			name: _('workshop'),
+			name: _('workshop 🛠️'),
 			button: null,
 			maximum: 1,
 			availableMsg: _("builder says she could make finer things, if she had the tools"),
@@ -134,7 +134,7 @@ var Room = {
 			audio: AudioLibrary.BUILD_WORKSHOP
 		},
 		'steelworks': {
-			name: _('steelworks'),
+			name: _('steelworks 🏭'),
 			button: null,
 			maximum: 1,
 			availableMsg: _("builder says the villagers could make steel, given the tools"),
@@ -150,7 +150,7 @@ var Room = {
 			audio: AudioLibrary.BUILD_STEELWORKS
 		},
 		'armoury': {
-			name: _('armoury'),
+			name: _('armoury 🛡️'),
 			button: null,
 			maximum: 1,
 			availableMsg: _("builder says it'd be useful to have a steady source of bullets"),
@@ -166,7 +166,7 @@ var Room = {
 			audio: AudioLibrary.BUILD_ARMOURY
 		},
 		'torch': {
-			name: _('torch'),
+			name: _('torch 🔥'),
 			button: null,
 			type: 'tool',
 			buildMsg: _('a torch to keep the dark away'),
@@ -179,7 +179,7 @@ var Room = {
 			audio: AudioLibrary.CRAFT_TORCH
 		},
 		'waterskin': {
-			name: _('waterskin'),
+			name: _('waterskin 💧'),
 			button: null,
 			type: 'upgrade',
 			maximum: 1,
@@ -192,7 +192,7 @@ var Room = {
 			audio: AudioLibrary.CRAFT_WATERSKIN
 		},
 		'cask': {
-			name: _('cask'),
+			name: _('cask 🛢️'),
 			button: null,
 			type: 'upgrade',
 			maximum: 1,
@@ -206,7 +206,7 @@ var Room = {
 			audio: AudioLibrary.CRAFT_CASK
 		},
 		'water tank': {
-			name: _('water tank'),
+			name: _('water tank 🌊'),
 			button: null,
 			type: 'upgrade',
 			maximum: 1,
@@ -220,7 +220,7 @@ var Room = {
 			audio: AudioLibrary.CRAFT_WATER_TANK
 		},
 		'bone spear': {
-			name: _('bone spear'),
+			name: _('bone spear 🦴'),
 			button: null,
 			type: 'weapon',
 			buildMsg: _("this spear's not elegant, but it's pretty good at stabbing"),
@@ -233,7 +233,7 @@ var Room = {
 			audio: AudioLibrary.CRAFT_BONE_SPEAR
 		},
 		'rucksack': {
-			name: _('rucksack'),
+			name: _('rucksack 🎒'),
 			button: null,
 			type: 'upgrade',
 			maximum: 1,
@@ -246,7 +246,7 @@ var Room = {
 			audio: AudioLibrary.CRAFT_RUCKSACK
 		},
 		'wagon': {
-			name: _('wagon'),
+			name: _('wagon 🚚'),
 			button: null,
 			type: 'upgrade',
 			maximum: 1,
@@ -260,7 +260,7 @@ var Room = {
 			audio: AudioLibrary.CRAFT_WAGON
 		},
 		'convoy': {
-			name: _('convoy'),
+			name: _('convoy 🚛'),
 			button: null,
 			type: 'upgrade',
 			maximum: 1,
@@ -275,7 +275,7 @@ var Room = {
 			audio: AudioLibrary.CRAFT_CONVOY
 		},
 		'l armour': {
-			name: _('l armour'),
+			name: _('l armour 👕'),
 			type: 'upgrade',
 			maximum: 1,
 			buildMsg: _("leather's not strong. better than rags, though."),
@@ -288,7 +288,7 @@ var Room = {
 			audio: AudioLibrary.CRAFT_LEATHER_ARMOUR
 		},
 		'i armour': {
-			name: _('i armour'),
+			name: _('i armour 👚'),
 			type: 'upgrade',
 			maximum: 1,
 			buildMsg: _("iron's stronger than leather"),
@@ -301,7 +301,7 @@ var Room = {
 			audio: AudioLibrary.CRAFT_IRON_ARMOUR
 		},
 		's armour': {
-			name: _('s armour'),
+			name: _('s armour 🧥'),
 			type: 'upgrade',
 			maximum: 1,
 			buildMsg: _("steel's stronger than iron"),
@@ -314,7 +314,7 @@ var Room = {
 			audio: AudioLibrary.CRAFT_STEEL_ARMOUR
 		},
 		'iron sword': {
-			name: _('iron sword'),
+			name: _('iron sword 🗡️'),
 			button: null,
 			type: 'weapon',
 			buildMsg: _("sword is sharp. good protection out in the wilds."),
@@ -328,7 +328,7 @@ var Room = {
 			audio: AudioLibrary.CRAFT_IRON_SWORD
 		},
 		'steel sword': {
-			name: _('steel sword'),
+			name: _('steel sword ⚔️'),
 			button: null,
 			type: 'weapon',
 			buildMsg: _("the steel is strong, and the blade true."),
@@ -342,7 +342,7 @@ var Room = {
 			audio: AudioLibrary.CRAFT_STEEL_SWORD
 		},
 		'rifle': {
-			name: _('rifle'),
+			name: _('rifle 🔫'),
 			type: 'weapon',
 			buildMsg: _("black powder and bullets, like the old days."),
 			cost: function () {

--- a/script/world.js
+++ b/script/world.js
@@ -2,25 +2,25 @@ var World = {
   RADIUS: 30,
   VILLAGE_POS: [30, 30],
   TILE: {
-    VILLAGE: 'A',
-    IRON_MINE: 'I',
-    COAL_MINE: 'C',
-    SULPHUR_MINE: 'S',
-    FOREST: ';',
-    FIELD: ',',
-    BARRENS: '.',
-    ROAD: '#',
-    HOUSE: 'H',
-    CAVE: 'V',
-    TOWN: 'O',
-    CITY: 'Y',
-    OUTPOST: 'P',
-    SHIP: 'W',
-    BOREHOLE: 'B',
-    BATTLEFIELD: 'F',
-    SWAMP: 'M',
-    CACHE: 'U',
-    EXECUTIONER: 'X'
+  VILLAGE: '🛖',
+    IRON_MINE: '⛏️',
+    COAL_MINE: '⛏️',
+    SULPHUR_MINE: '⛏️',
+    FOREST: '🌲',
+    FIELD: '🌾',
+    BARRENS: '🏜️',
+    ROAD: '🛤️',
+    HOUSE: '🏠',
+    CAVE: '🦇',
+    TOWN: '🏘️',
+    CITY: '🏙️',
+    OUTPOST: '🏕️',
+    SHIP: '🛸',
+    BOREHOLE: '🕳️',
+    BATTLEFIELD: '⚔️',
+    SWAMP: '🐊',
+    CACHE: '📦',
+    EXECUTIONER: '💀'
   },
   TILE_PROBS: {},
   LANDMARKS: {},
@@ -44,78 +44,78 @@ var World = {
 
   Weapons: {
     'fists': {
-      verb: _('punch'),
+      verb: _('punch 👊'),
       type: 'unarmed',
       damage: 1,
       cooldown: 2
     },
     'bone spear': {
-      verb: _('stab'),
+      verb: _('stab 🦴'),
       type: 'melee',
       damage: 2,
       cooldown: 2
     },
     'iron sword': {
-      verb: _('swing'),
+      verb: _('swing 🗡️'),
       type: 'melee',
       damage: 4,
       cooldown: 2
     },
     'steel sword': {
-      verb: _('slash'),
+      verb: _('slash ⚔️'),
       type: 'melee',
       damage: 6,
       cooldown: 2
     },
     'bayonet': {
-      verb: _('thrust'),
+      verb: _('thrust 🔪'),
       type: 'melee',
       damage: 8,
       cooldown: 2
     },
     'rifle': {
-      verb: _('shoot'),
+      verb: _('shoot 🔫'),
       type: 'ranged',
       damage: 5,
       cooldown: 1,
       cost: { 'bullets': 1 }
     },
     'laser rifle': {
-      verb: _('blast'),
+      verb: _('blast 💥'),
       type: 'ranged',
       damage: 8,
       cooldown: 1,
       cost: { 'energy cell': 1 }
     },
     'grenade': {
-      verb: _('lob'),
+      verb: _('lob 💣'),
       type: 'ranged',
       damage: 15,
       cooldown: 5,
       cost: { 'grenade': 1 }
     },
     'bolas': {
-      verb: _('tangle'),
+      verb: _('tangle ➰'),
       type: 'ranged',
       damage: 'stun',
       cooldown: 15,
       cost: { 'bolas': 1 }
     },
     'plasma rifle': {
-      verb: _('disintegrate'),
+      verb: _('disintegrate ✨'),
       type: 'ranged',
       damage: 12,
       cooldown: 1,
       cost: { 'energy cell': 1 }
     },
     'energy blade': {
-      verb: _('slice'),
+      verb: _('slice ⚡️'),
       type: 'melee',
       damage: 10,
       cooldown: 2
     },
     'disruptor': {
-      verb: _('stun'),
+      verb: _('stun 😵'),
       type: 'ranged',
       damage: 'stun',
       cooldown: 15
@@ -888,7 +888,7 @@ var World = {
           ttClass += " bottom";
         }
         if(World.curPos[0] == i && World.curPos[1] == j) {
-          mapString += '<span class="landmark">@<div class="tooltip ' + ttClass + '">'+_('Wanderer')+'</div></span>';
+          mapString += '<span class="landmark">🤺<div class="tooltip ' + ttClass + '">'+_('Wanderer')+'</div></span>';
         } else if(World.state.mask[i][j]) {
           var c = World.state.map[i][j];
           switch(c) {


### PR DESCRIPTION
Adds emojis to various parts of the game to enhance the visual experience.

- Replaces terrain tiles with emojis in `script/world.js`.
- Adds emojis to weapon verbs in `script/world.js`.
- Adds emojis to craftable item names in `script/room.js`.
- Adds emojis to various game text in `lang/adarkroom.pot`, including compass directions, room/fire status, and common events.